### PR TITLE
Fixed wrong prefix used in Heroku.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN npm ci --only=prod
 
 # These are added here as a way to define which env variables will be used.
 ENV DISCORD_TOKEN ""
-ENV PREFIX ""
+ENV BOT_PREFIX ""
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ docker run -it -e DISCORD_TOKEN="YOUR DISCORD TOKEN" moonstarx/discord-tts-bot:l
 The following environment variables can be used:
 
 * `DISCORD_TOKEN`: Your bot's Discord token. You can see how to get one on [this guide](https://github.com/moonstar-x/discord-downtime-notifier/wiki/Getting-a-Discord-Bot-Token).
-* `PREFIX`: The prefix that will be used for the commands. It defaults to `$`.
+* `BOT_PREFIX`: The prefix that will be used for the commands. It defaults to `$`.
 
 The following volumes can be used:
 

--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
     }
   ],
   "env": {
-    "PREFIX": {
+    "BOT_PREFIX": {
       "description": "Your bot's command prefix.",
       "value": "$",
       "required": true

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-tts-bot",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A simple Discord TTS Bot that uses the Google Translate TTS API",
   "main": "src/app.js",
   "scripts": {
     "start": "node ./src/app.js",
     "debug": "node ./src/app.js --debug",
-    "dev": "PREFIX=! nodemon --exec npm start",
+    "dev": "nodemon --exec npm start",
     "lint:errors-only": "node_modules/.bin/eslint src --quiet",
     "lint": "node_modules/.bin/eslint src"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -50,6 +50,7 @@ client.on('message', (message) => {
 
 client.on('ready', () => {
   logger.info('Connected to Discord! - Ready.');
+  logger.info(`Using prefix: ${prefix}`);
   client.updatePresence();
 });
 

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -5,7 +5,7 @@ const configFilePath = path.join(__dirname, '../../config/settings.json');
 const configFromFile = fs.existsSync(configFilePath) ? JSON.parse(fs.readFileSync(configFilePath)) : {};
 
 const discordToken = process.env.DISCORD_TOKEN || configFromFile.discord_token || null;
-const prefix = process.env.PREFIX || configFromFile.prefix || '$';
+const prefix = process.env.BOT_PREFIX || configFromFile.prefix || '$';
 
 module.exports = {
   discordToken,


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Code has been linted with the proper rules.

### :page_facing_up: Description

This PR changes the environment variable from PREFIX to BOT_PREFIX to fix Heroku or other systems from using something else as the bot's prefix.

### :pushpin: Does this PR address any issue?

No.
