### PR TITLE
Bugfix/4.0.1

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<center>
-    <img src="https://i.imgur.com/HT7Wmv1.jpg">
-</center>
+![banner](https://i.imgur.com/HT7Wmv1.jpg)
 
 [![discord](https://img.shields.io/discord/730998659008823296.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/mhj3Zsv)
 [![ci-build-status](https://img.shields.io/github/workflow/status/moonstar-x/discord-tts-bot/CI?logo=github)](https://github.com/moonstar-x/discord-tts-bot)
@@ -67,6 +65,42 @@ In case your bot is in a lot of servers (more than 2000), you should shard your 
 npm run start-sharded
 ```
 
+## Updating
+
+In order to update this bot, you should pull the latest changes:
+
+```text
+git pull origin master
+```
+
+And re-install the dependencies:
+
+```text
+rm -rf node_modules && npm install
+```
+
+Once this is done, you should re-deploy the commands:
+
+```text
+npm run deploy
+```
+
+And you're ready to go. Make sure you check the README everytime you wish to update in case there are breaking changes
+that may affect your current installation.
+
+## Creating your Bot Token
+
+Head over to [Discord Application Page](https://discord.com/developers/applications/) and create a new bot. Then, you should enable it as a bot
+by going into the `Bot` page and setting up your bot. Then, you should head over to the `OAuth2` page and select `OAuth2 URL Generator`. A box should show up
+with plenty of checkboxes, enable the `bot` and `application.commands` checkboxes. Then, another box should show up with more checkboxes, enable the following ones:
+
+* Send Messages
+* Read Message History
+* Connect
+* Speak
+
+At the bottom a link should show up, access this link to invite your bot. You should send this link to anyone that wishes to add your bot to their Discord server.
+
 ## Configuration
 
 Inside the `config` folder, rename the file *settings.json.example* to *settings.json* and edit the file with your own Discord Token and other settings. If you don't have a discord token yet, you can see a guide on how to create it [here](https://github.com/moonstar-x/discord-downtime-notifier/wiki).
@@ -92,18 +126,18 @@ You may also configure these options with environment variables. The settings se
 
 This table contains all the configuration settings you may specify with both environment variables and the JSON config file.
 
-| Environment Variable               | JSON Property                | Required                    | Type                       | Description                                                                                                                                                                                                                                                                                                              |
-|------------------------------------|------------------------------|-----------------------------|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| DISCORD_TOKEN                      | `token`                      | Yes.                        | `string`                   | The bot's token.                                                                                                                                                                                                                                                                                                         |
-| DISCORD_PREFIX                     | `prefix`                     | No. (Defaults to: `$`)      | `string`                   | **Deprecated**: The bot's prefix. A prefix is no longer necessary because this bot uses the all new interactions (slash commands).                                                                                                                                                                                       |
-| DISCORD_OWNER_ID                   | `owner_id`                   | No. (Defaults to: `null`)   | `string` or `null`         | The ID of the bot's owner.                                                                                                                                                                                                                                                                                               |
-| DISCORD_OWNER_REPORTING            | `owner_reporting`            | No. (Defaults to: `false`)  | `boolean`                  | Whether the bot should send error reports to the owner via DM when a command errors.                                                                                                                                                                                                                                     |
-| DISCORD_PRESENCE_REFRESH_INTERVAL  | `presence_refresh_interval`  | No. (Defaults to: `900000`) | `number` or `null`         | The time interval in milliseconds in which the bot updates its presence. If set to `null` the presence auto update will be disabled.                                                                                                                                                                                     |
-| DISCORD_DEFAULT_DISCONNECT_TIMEOUT | `default_disconnect_timeout` | No. (Defaults to: `5`)      | `number` or `null`         | The time it takes the bot to leave a voice channel when inactive by default on all servers. This setting can be customised per server and this will be used if a server has not set their own value.                                                                                                                     |
-| DISCORD_TESTING_GUILD_ID           | `testing_guild_id`           | No. (Defaults to: `null`)   | `string` or `null`         | The ID of the testing guild. You do not need to set this to anything if you're not planning on developing the bot.                                                                                                                                                                                                       |
-| DISCORD_PROVIDER_TYPE              | `provider_type`              | No. (Defaults to: `level`)  | Can be: `level` or `redis` | The type of data provider to use. [Level](https://github.com/google/leveldb) is a file based key-value store whereas [Redis](https://redis.io/) is a cache service. If you plan on just hosting the bot for a small server you should choose `level`, if you plan on sharding the client `redis` can be a better choice. |
-| DISCORD_REDIS_URL                  | `redis_url`                  | No. (Defaults to: `null`)   | `string` or `null`         | The URL of the redis service. This is only required if you have set the provider type to `redis`.                                                                                                                                                                                                                        |
-| DISCORD_ENABLE_TTS_CHANNELS        | `enable_tts_channels`        | No. (Defaults to: `false`)  | `boolean`                  | Whether to enable the message-only TTS for specific channels. With this setting, you can send TTS messages by just sending messages to a channel that you have enabled a provider for.                                                                                                                                   |
+| Environment Variable               | JSON Property                | Required                    | Type                       | Description                                                                                                                                                                                                                                                                                                                    |
+|------------------------------------|------------------------------|-----------------------------|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DISCORD_TOKEN                      | `token`                      | Yes.                        | `string`                   | The bot's token.                                                                                                                                                                                                                                                                                                               |
+| DISCORD_PREFIX                     | `prefix`                     | No. (Defaults to: `$`)      | `string`                   | **Deprecated**: The bot's prefix. A prefix is no longer necessary because this bot uses the all new interactions (slash commands).                                                                                                                                                                                             |
+| DISCORD_OWNER_ID                   | `owner_id`                   | No. (Defaults to: `null`)   | `string` or `null`         | The ID of the bot's owner.                                                                                                                                                                                                                                                                                                     |
+| DISCORD_OWNER_REPORTING            | `owner_reporting`            | No. (Defaults to: `false`)  | `boolean`                  | Whether the bot should send error reports to the owner via DM when a command errors.                                                                                                                                                                                                                                           |
+| DISCORD_PRESENCE_REFRESH_INTERVAL  | `presence_refresh_interval`  | No. (Defaults to: `900000`) | `number` or `null`         | The time interval in milliseconds in which the bot updates its presence. If set to `null` the presence auto update will be disabled.                                                                                                                                                                                           |
+| DISCORD_DEFAULT_DISCONNECT_TIMEOUT | `default_disconnect_timeout` | No. (Defaults to: `5`)      | `number` or `null`         | The time it takes the bot to leave a voice channel when inactive by default on all servers. This setting can be customised per server and this will be used if a server has not set their own value.                                                                                                                           |
+| DISCORD_TESTING_GUILD_ID           | `testing_guild_id`           | No. (Defaults to: `null`)   | `string` or `null`         | The ID of the testing guild. You do not need to set this to anything if you're not planning on developing the bot.                                                                                                                                                                                                             |
+| DISCORD_PROVIDER_TYPE              | `provider_type`              | No. (Defaults to: `level`)  | Can be: `level` or `redis` | The type of data provider to use. [Level](https://github.com/google/leveldb) is a file based key-value store whereas [Redis](https://redis.io/) is a cache service. If you plan on just hosting the bot for a small server you should choose `level`, if you plan on sharding the client `redis` can be a better choice.       |
+| DISCORD_REDIS_URL                  | `redis_url`                  | No. (Defaults to: `null`)   | `string` or `null`         | The URL of the redis service. This is only required if you have set the provider type to `redis`.                                                                                                                                                                                                                              |
+| DISCORD_ENABLE_TTS_CHANNELS        | `enable_tts_channels`        | No. (Defaults to: `false`)  | `boolean`                  | Whether to enable the message-only TTS for specific channels. With this setting, you can send TTS messages by just sending messages to a channel that you have enabled a provider for. You need the privileged message intent (accessible in the `Bot` page of your bot's application page) for this feature to work properly. |
 
 > If you set `enable_tts_channels` to `true`, you must enable the message content privileged intent in your bot's [application page](https://discord.com/developers/applications/).
 
@@ -121,6 +155,24 @@ The following volumes can be used:
 
 * `/opt/app/config`: The config folder for the bot, here you can use the `settings.json` file to configure the bot if you don't want to use environment variables.
 * `/opt/app/data`: The data folder for the bot. If you use a `level` data provider you should set this volume to keep the bot's data persistent across restarts.
+
+## Running on Repl.it
+
+To run this bot on Repl.it, create a new Repl by importing this repository. Then, run the following commands:
+
+```bash
+chmod +x init-replit.sh
+./init-replit.sh
+```
+
+This will set up the proper node environment for the bot.
+
+Then, after you have [configured](#configuration) your bot, you should deploy your commands and start the bot with:
+
+```text
+npm run deploy
+npm start
+```
 
 ## Deploying to Heroku
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,13 @@ This table contains all the configuration settings you may specify with both env
 
 ## Running on Docker
 
-You can start a container with the bot's image by running:
+Before you run this image, you should deploy your commands, you can do so by running:
+
+```text
+ docker run -it --rm -e DISCORD_TOKEN="your_token" -e DISCORD_ENABLE_TTS_CHANNELS="true/false" moonstarx/discord-tts-bot npm run deploy
+```
+
+After that, you can start a container with the bot's image by running:
 
 ```text
 docker run -it -e DISCORD_TOKEN="YOUR DISCORD TOKEN" moonstarx/discord-tts-bot:latest

--- a/init-replit.sh
+++ b/init-replit.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+echo "Removing old node_modules..."
+rm -rf node_modules
+
+echo "Installing node@16.6.1..."
+npm i --save-dev node@16.6.1
+
+echo "Configuring npm node@16.6.1..."
+npm config set prefix=$(pwd)/node_modules/node
+export PATH=$(pwd)/node_modules/node/bin:$PATH
+
+echo "Reinstalling dependencies..."
+npm install
+
+echo "Installing ffmpeg-static..."
+npm install --save-dev ffmpeg-static

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@discordjs/builders": "^0.11.0",
         "@discordjs/opus": "^0.5.3",
         "@discordjs/voice": "^0.7.5",
-        "@greencoast/discord.js-extended": "^2.2.0",
+        "@greencoast/discord.js-extended": "^2.2.1",
         "@greencoast/logger": "^1.1.0",
         "axios": "^0.25.0",
         "deepmerge": "^4.2.2",
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
-      "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -215,9 +215,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.8.tgz",
-      "integrity": "sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.10.tgz",
+      "integrity": "sha512-Sm/S9Or6nN8uiFsQU1yodyDW3MWXQhFeqzMPM+t8MJjM+pLsnFVxFZzkpXKvUXh+Gz9cbMoYYs484+Jw/NTEFQ==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -283,9 +283,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.8.tgz",
-      "integrity": "sha512-xe+H7JlvKsDQwXRsBhSnq1/+9c+LlQcCK3Tn/l5sbx02HYns/cn7ibp9+RV1sIUqu7hKg91NWsgHurO9dowITQ==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.10.tgz",
+      "integrity": "sha512-yzuaYXoRJBGMlBhsMJoUW7G1UmSb/eXr/JHYM/MsOJgavJibLwASijW7oXBdw3NQ6T0bW7Ty5P/VarOs9cHmqw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -295,7 +295,7 @@
         "@babel/helper-function-name": "^7.16.7",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.16.8",
+        "@babel/parser": "^7.16.10",
         "@babel/types": "^7.16.8",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -513,9 +513,9 @@
       }
     },
     "node_modules/@greencoast/discord.js-extended": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@greencoast/discord.js-extended/-/discord.js-extended-2.2.0.tgz",
-      "integrity": "sha512-/KrXytGXX6QiO+YDJlHWNx/tDcHHd4NJ/NDY8q5s6f+So780KvyvJ2BOTQirD5N+4m0hLJDgojYFAHaMOeFx8g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@greencoast/discord.js-extended/-/discord.js-extended-2.2.1.tgz",
+      "integrity": "sha512-+CzbRIk3qNT1nvvqvDoNYYdRBnN67OH3Zu6qTi4FDoIN6mreDN3O5jAWHeDjj+3lWcGSFXBqEeCCYF4/GDfEcA==",
       "dependencies": {
         "@discordjs/builders": "^0.11.0",
         "@discordjs/rest": "^0.2.0-canary.0",
@@ -677,9 +677,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.9.tgz",
-      "integrity": "sha512-5dNBXu/FOER+EXnyah7rn8xlNrfMOQb/qXnw4NQgLkCygKBKhdmF/CA5oXVOKZLBEahw8s2WP9LxIcN/oDDRgQ=="
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
+      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -2014,9 +2014,9 @@
       "peer": true
     },
     "node_modules/eslint-config-greencoast/node_modules/resolve": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-      "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.1.tgz",
+      "integrity": "sha512-lfEImVbnolPuaSZuLQ52cAxPBHeI77sPwCOWRdy12UG/CNa8an7oBHH1R+Fp1/mUqSJi4c8TIP6FOIPSZAUrEQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-      "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.1.tgz",
+      "integrity": "sha512-lfEImVbnolPuaSZuLQ52cAxPBHeI77sPwCOWRdy12UG/CNa8an7oBHH1R+Fp1/mUqSJi4c8TIP6FOIPSZAUrEQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -4875,9 +4875,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -5215,9 +5215,9 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
-      "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -5284,9 +5284,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.8.tgz",
-      "integrity": "sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.10.tgz",
+      "integrity": "sha512-Sm/S9Or6nN8uiFsQU1yodyDW3MWXQhFeqzMPM+t8MJjM+pLsnFVxFZzkpXKvUXh+Gz9cbMoYYs484+Jw/NTEFQ==",
       "dev": true,
       "peer": true
     },
@@ -5336,9 +5336,9 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.8.tgz",
-      "integrity": "sha512-xe+H7JlvKsDQwXRsBhSnq1/+9c+LlQcCK3Tn/l5sbx02HYns/cn7ibp9+RV1sIUqu7hKg91NWsgHurO9dowITQ==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.10.tgz",
+      "integrity": "sha512-yzuaYXoRJBGMlBhsMJoUW7G1UmSb/eXr/JHYM/MsOJgavJibLwASijW7oXBdw3NQ6T0bW7Ty5P/VarOs9cHmqw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -5348,7 +5348,7 @@
         "@babel/helper-function-name": "^7.16.7",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.16.8",
+        "@babel/parser": "^7.16.10",
         "@babel/types": "^7.16.8",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -5529,9 +5529,9 @@
       }
     },
     "@greencoast/discord.js-extended": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@greencoast/discord.js-extended/-/discord.js-extended-2.2.0.tgz",
-      "integrity": "sha512-/KrXytGXX6QiO+YDJlHWNx/tDcHHd4NJ/NDY8q5s6f+So780KvyvJ2BOTQirD5N+4m0hLJDgojYFAHaMOeFx8g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@greencoast/discord.js-extended/-/discord.js-extended-2.2.1.tgz",
+      "integrity": "sha512-+CzbRIk3qNT1nvvqvDoNYYdRBnN67OH3Zu6qTi4FDoIN6mreDN3O5jAWHeDjj+3lWcGSFXBqEeCCYF4/GDfEcA==",
       "requires": {
         "@discordjs/builders": "^0.11.0",
         "@discordjs/rest": "^0.2.0-canary.0",
@@ -5651,9 +5651,9 @@
       "peer": true
     },
     "@types/node": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.9.tgz",
-      "integrity": "sha512-5dNBXu/FOER+EXnyah7rn8xlNrfMOQb/qXnw4NQgLkCygKBKhdmF/CA5oXVOKZLBEahw8s2WP9LxIcN/oDDRgQ=="
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
+      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -6615,9 +6615,9 @@
           "peer": true
         },
         "resolve": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-          "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.1.tgz",
+          "integrity": "sha512-lfEImVbnolPuaSZuLQ52cAxPBHeI77sPwCOWRdy12UG/CNa8an7oBHH1R+Fp1/mUqSJi4c8TIP6FOIPSZAUrEQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -6650,9 +6650,9 @@
           }
         },
         "resolve": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-          "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+          "version": "1.21.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.1.tgz",
+          "integrity": "sha512-lfEImVbnolPuaSZuLQ52cAxPBHeI77sPwCOWRdy12UG/CNa8an7oBHH1R+Fp1/mUqSJi4c8TIP6FOIPSZAUrEQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -8719,9 +8719,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "peer": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-tts-bot",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@discordjs/builders": "^0.11.0",
     "@discordjs/opus": "^0.5.3",
     "@discordjs/voice": "^0.7.5",
-    "@greencoast/discord.js-extended": "^2.2.0",
+    "@greencoast/discord.js-extended": "^2.2.1",
     "@greencoast/logger": "^1.1.0",
     "axios": "^0.25.0",
     "deepmerge": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-tts-bot",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A simple Discord TTS Bot that uses the Google Translate TTS API.",
   "main": "./src/app.js",
   "scripts": {

--- a/src/app.js
+++ b/src/app.js
@@ -134,9 +134,13 @@ client.once('ready', async() => {
     const commandName = args.shift()?.toLowerCase();
     const command = client.registry.resolveCommand(commandName);
 
-    if (command) {
-      const localizer = client.localizer.getLocalizer(message.guild);
-      return message.reply(localizer.t('app.message.deprecated', { commandName }));
+    try {
+      if (command) {
+        const localizer = client.localizer.getLocalizer(message.guild);
+        return message.reply(localizer.t('app.message.deprecated', { commandName }));
+      }
+    } catch (error) {
+      client.emit('error', error);
     }
   });
 });

--- a/src/app.js
+++ b/src/app.js
@@ -120,8 +120,13 @@ client.once('ready', async() => {
     client.ttsChannelHandler.initialize();
   }
 
+  client.on('guildCreate', async(guild) => {
+    await client.initializeDependenciesForGuild(guild);
+  });
+
   client.on('guildDelete', async(guild) => {
     await client.dataProvider.clear(guild);
+    client.deleteDependenciesForGuild(guild);
   });
 
   // This will be removed in a future update.

--- a/src/app.js
+++ b/src/app.js
@@ -106,7 +106,7 @@ const createProvider = (type) => {
   }
 };
 
-client.on('ready', async() => {
+client.once('ready', async() => {
   await client.setDataProvider(createProvider(config.get('PROVIDER_TYPE')));
   await client.initializeDependencies();
   await client.localizer.init();
@@ -119,26 +119,26 @@ client.on('ready', async() => {
   if (config.get('ENABLE_TTS_CHANNELS')) {
     client.ttsChannelHandler.initialize();
   }
-});
 
-client.on('guildDelete', async(guild) => {
-  await client.dataProvider.clear(guild);
-});
+  client.on('guildDelete', async(guild) => {
+    await client.dataProvider.clear(guild);
+  });
 
-// This will be removed in a future update.
-client.on('messageCreate', (message) => {
-  if (message.author.bot || !message.guild || !message.content.startsWith(client.prefix)) {
-    return;
-  }
+  // This will be removed in a future update.
+  client.on('messageCreate', (message) => {
+    if (message.author.bot || !message.guild || !message.content.startsWith(client.prefix)) {
+      return;
+    }
 
-  const args = message.content.slice(client.prefix.length).trim().split(/ +/);
-  const commandName = args.shift()?.toLowerCase();
-  const command = client.registry.resolveCommand(commandName);
+    const args = message.content.slice(client.prefix.length).trim().split(/ +/);
+    const commandName = args.shift()?.toLowerCase();
+    const command = client.registry.resolveCommand(commandName);
 
-  if (command) {
-    const localizer = client.localizer.getLocalizer(message.guild);
-    return message.reply(localizer.t('app.message.deprecated', { commandName }));
-  }
+    if (command) {
+      const localizer = client.localizer.getLocalizer(message.guild);
+      return message.reply(localizer.t('app.message.deprecated', { commandName }));
+    }
+  });
 });
 
 client.login(config.get('TOKEN'));

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ const LevelDataProvider = require('@greencoast/discord.js-extended/dist/provider
 const TTSClient = require('./classes/extensions/TTSClient');
 const { locales } = require('./locales');
 const { DISCONNECT_TIMEOUT } = require('./common/constants');
+const pkg = require('../package.json');
 
 const SUPPORTED_PROVIDERS = ['level', 'redis'];
 
@@ -62,9 +63,10 @@ const client = new TTSClient({
     refreshInterval: config.get('PRESENCE_REFRESH_INTERVAL'),
     templates: [
       '{num_guilds} servers!',
-      '{prefix}help for help.',
+      '/help for help.',
       '{num_members} users!',
-      'up for {uptime}.'
+      'up for {uptime}.',
+      `Current version: ${pkg.version}`
     ]
   },
   testingGuildID: config.get('TESTING_GUILD_ID'),

--- a/src/commands/all-tts/SayCommand.js
+++ b/src/commands/all-tts/SayCommand.js
@@ -25,6 +25,8 @@ class SayCommand extends SlashCommand {
   }
 
   async run(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+
     const localizer = this.client.localizer.getLocalizer(interaction.guild);
     const ttsPlayer = this.client.getTTSPlayer(interaction.guild);
     const connection = ttsPlayer.voice.getConnection();
@@ -43,26 +45,29 @@ class SayCommand extends SlashCommand {
     });
 
     if (!memberChannel) {
-      return interaction.reply({ content: localizer.t('command.say.no_channel'), ephemeral: true });
+      await interaction.editReply(localizer.t('command.say.no_channel'));
+      return;
     }
 
     if (connection) {
       if (myChannel !== memberChannel) {
-        return interaction.reply({ content: localizer.t('command.say.different_channel'), ephemeral: true });
+        await interaction.editReply(localizer.t('command.say.different_channel'));
+        return;
       }
 
-      await interaction.reply({ content: localizer.t('command.say.success'), ephemeral: true });
+      await interaction.editReply(localizer.t('command.say.success'));
       return ttsPlayer.say(message, currentSettings.provider, extras);
     }
 
     const cantConnectReason = getCantConnectToChannelReason(memberChannel);
     if (cantConnectReason) {
-      return interaction.reply({ content: localizer.t(cantConnectReason), ephemeral: true });
+      await interaction.editReply(localizer.t(cantConnectReason));
+      return;
     }
 
     await ttsPlayer.voice.connect(memberChannel);
     logger.info(`Joined ${memberChannel.name} in ${guildName}.`);
-    await interaction.reply({ content: localizer.t('command.say.joined', { channel: memberChannel.toString() }) });
+    await interaction.editReply(localizer.t('command.say.joined', { channel: memberChannel.toString() }));
     return ttsPlayer.say(message, currentSettings.provider, extras);
   }
 }

--- a/src/commands/config/SetTimeoutCommand.js
+++ b/src/commands/config/SetTimeoutCommand.js
@@ -29,7 +29,7 @@ class SetTimeoutCommand extends SlashCommand {
     const timeout = interaction.options.getNumber('timeout');
     const ttsPlayer = this.client.getTTSPlayer(interaction.guild);
 
-    if (timeout > DISCONNECT_TIMEOUT.MIN || timeout < DISCONNECT_TIMEOUT.MAX) {
+    if (timeout < DISCONNECT_TIMEOUT.MIN || timeout > DISCONNECT_TIMEOUT.MAX) {
       return interaction.reply({ content: localizer.t('command.timeout.out_of_range', { min: DISCONNECT_TIMEOUT.MIN, max: DISCONNECT_TIMEOUT.MAX }) });
     }
 

--- a/src/commands/google-tts/GoogleSayCommand.js
+++ b/src/commands/google-tts/GoogleSayCommand.js
@@ -25,6 +25,8 @@ class GoogleSayCommand extends SlashCommand {
   }
 
   async run(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+
     const localizer = this.client.localizer.getLocalizer(interaction.guild);
     const ttsPlayer = this.client.getTTSPlayer(interaction.guild);
     const connection = ttsPlayer.voice.getConnection();
@@ -43,26 +45,29 @@ class GoogleSayCommand extends SlashCommand {
     });
 
     if (!memberChannel) {
-      return interaction.reply({ content: localizer.t('command.say.no_channel'), ephemeral: true });
+      await interaction.editReply(localizer.t('command.say.no_channel'));
+      return;
     }
 
     if (connection) {
       if (myChannel !== memberChannel) {
-        return interaction.reply({ content: localizer.t('command.say.different_channel'), ephemeral: true });
+        await interaction.editReply(localizer.t('command.say.different_channel'));
+        return;
       }
 
-      await interaction.reply({ content: localizer.t('command.say.success'), ephemeral: true });
+      await interaction.editReply(localizer.t('command.say.success'));
       return ttsPlayer.say(message, GoogleProvider.NAME, extras);
     }
 
     const cantConnectReason = getCantConnectToChannelReason(memberChannel);
     if (cantConnectReason) {
-      return interaction.reply({ content: localizer.t(cantConnectReason), ephemeral: true });
+      await interaction.editReply(localizer.t(cantConnectReason));
+      return;
     }
 
     await ttsPlayer.voice.connect(memberChannel);
     logger.info(`Joined ${memberChannel.name} in ${guildName}.`);
-    await interaction.reply({ content: localizer.t('command.say.joined', { channel: memberChannel.toString() }) });
+    await interaction.editReply(localizer.t('command.say.joined', { channel: memberChannel.toString() }));
     return ttsPlayer.say(message, GoogleProvider.NAME, extras);
   }
 }

--- a/src/commands/other-tts/SayAeiouCommand.js
+++ b/src/commands/other-tts/SayAeiouCommand.js
@@ -25,6 +25,8 @@ class SayAeiouCommand extends SlashCommand {
   }
 
   async run(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+
     const localizer = this.client.localizer.getLocalizer(interaction.guild);
     const ttsPlayer = this.client.getTTSPlayer(interaction.guild);
     const connection = ttsPlayer.voice.getConnection();
@@ -40,26 +42,29 @@ class SayAeiouCommand extends SlashCommand {
     });
 
     if (!memberChannel) {
-      return interaction.reply({ content: localizer.t('command.say.no_channel'), ephemeral: true });
+      await interaction.editReply(localizer.t('command.say.no_channel'));
+      return;
     }
 
     if (connection) {
       if (myChannel !== memberChannel) {
-        return interaction.reply({ content: localizer.t('command.say.different_channel'), ephemeral: true });
+        await interaction.editReply(localizer.t('command.say.different_channel'));
+        return;
       }
 
-      await interaction.reply({ content: localizer.t('command.say.success'), ephemeral: true });
+      await interaction.editReply(localizer.t('command.say.success'));
       return ttsPlayer.say(message, AeiouProvider.NAME);
     }
 
     const cantConnectReason = getCantConnectToChannelReason(memberChannel);
     if (cantConnectReason) {
-      return interaction.reply({ content: localizer.t(cantConnectReason), ephemeral: true });
+      await interaction.editReply(localizer.t(cantConnectReason));
+      return;
     }
 
     await ttsPlayer.voice.connect(memberChannel);
     logger.info(`Joined ${memberChannel.name} in ${guildName}.`);
-    await interaction.reply({ content: localizer.t('command.say.joined', { channel: memberChannel.toString() }) });
+    await interaction.editReply(localizer.t('command.say.joined', { channel: memberChannel.toString() }));
     return ttsPlayer.say(message, AeiouProvider.NAME);
   }
 }


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Code has been linted with the proper rules.

### :page_facing_up: Description

This PR corresponds to the version 4.0.1 of this bot, this includes the following changes:

- Fixed a bug in the command deployment script where it would throw an error related to config types.
- Fixed a bug where any command would throw in a newly joined server because no localizer was initialized for it.
- Fixed a bug where the bot would crash if it left a server due to trying to clear data from the redis data provider when no data was saved prior.
- Fixed wrong prefix in help presence message. Added a current version presence message.
- Fixed a bug where the bot would crash if it left a server before the data provider was ready.
- Fixed a bug where the bot would crash if someone tried to send a prefixed command in a channel where the bot has no permissions to reply.
- Fixed a bug where no TTSPlayer would be instantiated for newly joined servers.
- Fixed a bug where TTSPlayer instances would not be removed when leaving servers.
- Fixed a bug where the interaction would show up as failed if any of the TTS providers would take longer than 3 seconds to resolve the TTS resource.
- Fixed a bug where the `set_timeout` command would not accept valid timeout values.
- Added a `init-replit.sh` script to facilitate the setup of the node environment for Repl.it users. Check the [README](https://github.com/moonstar-x/discord-tts-bot#running-on-replit) for more information on how to use it.

### :pushpin: Does this PR address any issue?

#61
