### PR TITLE
URLs are now automatically omitted from TTS messages

### DIFF
--- a/src/classes/tts/TTSPlayer.js
+++ b/src/classes/tts/TTSPlayer.js
@@ -4,134 +4,135 @@ const Queue = require('../Queue');
 const VoiceManager = require('../VoiceManager');
 
 class TTSPlayer {
-  constructor(client, guild, disconnectScheduler) {
-    this.client = client;
-    this.guild = guild;
-    this.disconnectScheduler = disconnectScheduler;
-    this.providerManager = client.providerManager;
+    constructor(client, guild, disconnectScheduler) {
+        this.client = client;
+        this.guild = guild;
+        this.disconnectScheduler = disconnectScheduler;
+        this.providerManager = client.providerManager;
 
-    this.queue = new Queue();
-    this.speaking = false;
-    this.voice = new VoiceManager(guild);
-
-    this.initializePlayer();
-    this.initializeScheduler();
-  }
-
-  initializePlayer() {
-    this.voice.player.on('error', (error) => {
-      logger.error(error);
-      this.speaking = false;
-      this.play();
-    });
-
-    this.voice.player.on('idle', () => {
-      if (this.speaking) {
+        this.queue = new Queue();
         this.speaking = false;
-        this.play();
-      }
-    });
-  }
+        this.voice = new VoiceManager(guild);
 
-  initializeScheduler() {
-    this.disconnectScheduler.set(() => {
-      const channel = this.stop();
-      logger.warn(`Left ${channel.name} from ${this.guild.name} due to inactivity.`);
-    });
-  }
-
-  async say(sentence, providerName, extras = {}) {
-  // URL Detector
-  const urlRegex = /(https?:\/\/[^\s]+)/g;
-
-  // Replace URL with SUS
-  let sanitizedSentence = sentence.replace(urlRegex, 'ඞ');
-
-  const provider = this.providerManager.getProvider(providerName);
-  const payload = await provider.createPayload(sanitizedSentence, extras);
-
-  if (Array.isArray(payload)) {
-    payload.forEach((p) => this.queue.enqueue(p));
-  } else {
-    this.queue.enqueue(payload);
-  }
-
-  this.startDisconnectScheduler();
-
-  if (!this.speaking) {
-    this.play();
-  }
-}
-  async play() {
-    if (this.queue.isEmpty()) {
-      return;
+        this.initializePlayer();
+        this.initializeScheduler();
     }
 
-    const payload = this.queue.dequeue();
-    const provider = this.providerManager.getProvider(payload.providerName);
+    initializePlayer() {
+        this.voice.player.on('error', (error) => {
+            logger.error(error);
+            this.speaking = false;
+            this.play();
+        });
 
-    logger.info(provider.getPlayLogMessage(payload, this.guild));
+        this.voice.player.on('idle', () => {
+            if (this.speaking) {
+                this.speaking = false;
+                this.play();
+            }
+        });
+    }
 
-    this.speaking = true;
-    this.voice.play(createAudioResource(payload.resource, {
-      metadata: {
-        title: payload.sentence
-      }
-    }));
-  }
+    initializeScheduler() {
+        this.disconnectScheduler.set(() => {
+            const channel = this.stop();
+            logger.warn(`Left ${channel.name} from ${this.guild.name} due to inactivity.`);
+        });
+    }
+
+    async say(sentence, providerName, extras = {}) {
+        // URL Detector
+        const urlRegex = /(https?:\/\/[^\s]+)/g;
+
+        // Replace URL with SUS
+        const sanitizedSentence = sentence.replace(urlRegex, 'ඞ');
+
+        const provider = this.providerManager.getProvider(providerName);
+        const payload = await provider.createPayload(sanitizedSentence, extras);
+
+        if (Array.isArray(payload)) {
+            payload.forEach((p) => this.queue.enqueue(p));
+        } else {
+            this.queue.enqueue(payload);
+        }
+
+        this.startDisconnectScheduler();
+
+        if (!this.speaking) {
+            this.play();
+        }
+    }
+
+    async play() {
+        if (this.queue.isEmpty()) {
+            return;
+        }
+
+        const payload = this.queue.dequeue();
+        const provider = this.providerManager.getProvider(payload.providerName);
+
+        logger.info(provider.getPlayLogMessage(payload, this.guild));
+
+        this.speaking = true;
+        this.voice.play(createAudioResource(payload.resource, {
+            metadata: {
+                title: payload.sentence
+            }
+        }));
+    }
 
     skip() {
-    this.stopDisconnectScheduler();
+        this.stopDisconnectScheduler();
 
-    if (this.queue.length > 0) {
-      this.queue.shift();
+        if (this.queue.length > 0) {
+            this.queue.shift();
+        }
+
+        this.speaking = false;
+        this.voice.player.stop(true);
+
+        if (this.queue.length > 0) {
+            const nextMessage = this.queue[0];
+            this.say(nextMessage.text, nextMessage.provider, nextMessage.extras);
+        } else {
+            this.voice.disconnect();
+        }
     }
 
-    this.speaking = false;
-    this.voice.player.stop(true);
+    stop() {
+        const { channel } = this.guild.me.voice;
 
-    if (this.queue.length > 0) {
-      const nextMessage = this.queue[0];
-      this.say(nextMessage.text, nextMessage.provider, nextMessage.extras);
-    } else {
-      this.voice.disconnect();
-    }
-  }
-    
-  stop() {
-    const { channel } = this.guild.me.voice;
+        this.stopDisconnectScheduler();
 
-    this.stopDisconnectScheduler();
+        this.queue.clear();
+        this.speaking = false;
+        this.voice.disconnect();
+        this.voice.player.stop(true);
 
-    this.queue.clear();
-    this.speaking = false;
-    this.voice.disconnect();
-    this.voice.player.stop(true);
-
-    return channel || { name: 'null' };
-  }
-
-  startDisconnectScheduler() {
-    if (!this.disconnectScheduler) {
-      return;
+        return channel || { name: 'null' };
     }
 
-    if (this.disconnectScheduler.isAlive()) {
-      this.disconnectScheduler.refresh();
-    } else {
-      this.disconnectScheduler.start(this);
-    }
-  }
+    startDisconnectScheduler() {
+        if (!this.disconnectScheduler) {
+            return;
+        }
 
-  stopDisconnectScheduler() {
-    if (!this.disconnectScheduler) {
-      return;
+        if (this.disconnectScheduler.isAlive()) {
+            this.disconnectScheduler.refresh();
+        } else {
+            this.disconnectScheduler.start(this);
+        }
     }
 
-    if (this.disconnectScheduler.isAlive()) {
-      this.disconnectScheduler.stop();
+    stopDisconnectScheduler() {
+        if (!this.disconnectScheduler) {
+            return;
+        }
+
+        if (this.disconnectScheduler.isAlive()) {
+            this.disconnectScheduler.stop();
+        }
     }
-  }
 }
 
 module.exports = TTSPlayer;


### PR DESCRIPTION
Links / URLs are omitted

### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [✅] Code has been linted with the proper rules.

### :page_facing_up: Description

> This update modifies the TTSPlayer.js file to replace any URLs in the message with the symbol "ඞ". The omission of URLs is logged in the console.
> The symbol "ඞ" is used because it does not produce any sound when read by the TTS, ensuring URLs are skipped silently.

### :pushpin: Does this PR address any issue?

> N/A
